### PR TITLE
Properly escape quotes in titles and descriptions

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -5,7 +5,16 @@ module Jekyll
 
     def render(context)
       @context = context
-      Liquid::Template.parse(template_contents).render!(payload, info).gsub(/[\n\s]{2,}/, "\n")
+      output = Liquid::Template.parse(template_contents).render!(payload, info)
+
+      # Minify
+      output.gsub!(/[\n\s]{2,}/, "\n")
+
+      # Encode smart quotes. See https://github.com/benbalter/jekyll-seo-tag/pull/6
+      output.gsub!("\u201c", "&ldquo;")
+      output.gsub!("\u201d", "&rdquo;")
+
+      output
     end
 
     private

--- a/lib/template.html
+++ b/lib/template.html
@@ -18,7 +18,7 @@
 	{% endif %}
 {% endif %}
 {% if seo_title %}
-  {% assign seo_title = seo_title | replace:'"','&quot;' | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
+  {% assign seo_title = seo_title | escape | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
 {% endif %}
 
 {% if page.description %}
@@ -27,7 +27,7 @@
   {% assign seo_description = site.description %}
 {% endif %}
 {% if seo_description %}
-  {% assign seo_description = seo_description | replace:'"','&quot;' | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
+  {% assign seo_description = seo_description | escape | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
 {% endif %}
 
 {% if seo_title %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -18,7 +18,7 @@
 	{% endif %}
 {% endif %}
 {% if seo_title %}
-  {% assign seo_title = seo_title | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_title = seo_title | replace:'"','&quot;' | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
 {% endif %}
 
 {% if page.description %}
@@ -27,7 +27,7 @@
   {% assign seo_description = site.description %}
 {% endif %}
 {% if seo_description %}
-  {% assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_description = seo_description | replace:'"','&quot;' | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
 {% endif %}
 
 {% if seo_title %}

--- a/lib/template.html
+++ b/lib/template.html
@@ -18,7 +18,7 @@
 	{% endif %}
 {% endif %}
 {% if seo_title %}
-  {% assign seo_title = seo_title | escape | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
+  {% assign seo_title = seo_title | markdownify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
 {% if page.description %}
@@ -27,7 +27,7 @@
   {% assign seo_description = site.description %}
 {% endif %}
 {% if seo_description %}
-  {% assign seo_description = seo_description | escape | markdownify | strip_html | strip_newlines | replace:'"','&quot;' | escape_once %}
+  {% assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
 {% if seo_title %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -35,7 +35,14 @@ describe Jekyll::SeoTag do
   it "escapes titles" do
     site = site({"title" => 'Jekyll & "Hyde"'})
     context = context({ :site => site })
-    expect(subject.render(context)).to match(/<title>Jekyll &amp; “Hyde”<\/title>/)
+    expect(subject.render(context)).to match(/<title>Jekyll &amp; &quot;Hyde&quot;<\/title>/)
+  end
+
+  it "escapes descriptions" do
+    site = site({"description" => 'Jekyll & "Hyde"'})
+    context = context({ :site => site })
+    expected = /<meta name="description" content="Jekyll &amp; &quot;Hyde&quot;" \/>/
+    expect(subject.render(context)).to match(expected)
   end
 
   it "uses the page description" do

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -35,13 +35,13 @@ describe Jekyll::SeoTag do
   it "escapes titles" do
     site = site({"title" => 'Jekyll & "Hyde"'})
     context = context({ :site => site })
-    expect(subject.render(context)).to match(/<title>Jekyll &amp; &quot;Hyde&quot;<\/title>/)
+    expect(subject.render(context)).to match(/<title>Jekyll &amp; &ldquo;Hyde&rdquo;<\/title>/)
   end
 
   it "escapes descriptions" do
     site = site({"description" => 'Jekyll & "Hyde"'})
     context = context({ :site => site })
-    expected = /<meta name="description" content="Jekyll &amp; &quot;Hyde&quot;" \/>/
+    expected = /<meta name="description" content="Jekyll &amp; &ldquo;Hyde&rdquo;" \/>/
     expect(subject.render(context)).to match(expected)
   end
 


### PR DESCRIPTION
@parkr I could use your :books: here, if there's a better way to do this. I've tried doing things a million ways. Here's what I've learned:

* Kramdown converts dumb quotes to smart quotes
* Smart quotes are not escaped by `escape` or its variants, but are treated as dumb quotes for purposes of parsing and validation by many parsers
* If quotes are encoded as `&quot` before being passed to Kramdown, Kramdown changes them to dumb quotes
* All software is terrible

Halp? 