### PR TITLE
Do not build Gem on CI

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -3,4 +3,3 @@
 set -ex
 
 bundle exec rake spec
-bundle exec gem build jekyll-seo-tag.gemspec


### PR DESCRIPTION
I don't think there is a reason to build the Gem from CI, is there?
That's what `script/release` is for, right?