### PR TITLE
Strip trailing /index.html from seo_url

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -41,8 +41,8 @@
 {% endif %}
 
 {% if seo_url %}
-  <link rel="canonical" href="{{ seo_url }}{{ page.url }}" itemprop="url" />
-  <meta property='og:url' content='{{ seo_url }}{{ page.url }}' />
+  <link rel="canonical" href="{{ seo_url }}{{ page.url | replace:'/index.html','/' }}" itemprop="url" />
+  <meta property='og:url' content='{{ seo_url }}{{ page.url | replace:'/index.html','/' }}' />
 {% endif %}
 
 {% if site.title %}
@@ -64,10 +64,10 @@
 {% if page.date %}
   <meta property="og:type" content="article" />
   {% if page.next.url %}
-    <link rel="next" href="{{ seo_url }}{{ page.next.url }}" title="{{ page.next.title | escape }}" />
+    <link rel="next" href="{{ seo_url }}{{ page.next.url | replace:'/index.html','/' }}" title="{{ page.next.title | escape }}" />
   {% endif %}
   {% if page.previous.url %}
-    <link rel="prev" href="{{ seo_url }}{{ page.previous.url }}" title="{{ page.previous.title | escape }}" />
+    <link rel="prev" href="{{ seo_url }}{{ page.previous.url | replace:'/index.html','/' }}" title="{{ page.previous.title | escape }}" />
   {% endif %}
   <script type="application/ld+json">
     {

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -77,6 +77,15 @@ describe Jekyll::SeoTag do
     expect(subject.render(context)).to match(expected)
   end
 
+  it "uses replaces '/index.html' with '/'" do
+    page = page({ "permalink" => "/page/index.html" })
+    site = site({ "url" => "http://example.invalid" })
+    context = context({ :page => page, :site => site })
+    expected = %r!<link rel="canonical" href="http://example.invalid/page/" itemprop="url" />!
+    expected = %r!<meta property='og:url' content='http://example.invalid/page/' />!
+    expect(subject.render(context)).to match(expected)
+  end
+
   it "outputs the site title meta" do
     site = site({"title" => "Foo", "url" => "http://example.invalid"})
     context = context({ :site => site })


### PR DESCRIPTION
Fixes #2 

This replace technique is the same as [what is used by **jekyll-sitemap**](https://github.com/jekyll/jekyll-sitemap/blob/v0.9.0/lib/sitemap.xml#L16)

What happens if the post is actually just in a subdirectory called `/index.html/`? Every thing falls apart, I guess :egg: