### PR TITLE
Add smartify filter

### DIFF
--- a/jekyll-seo-tag.gemspec
+++ b/jekyll-seo-tag.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", ">= 2.0"
+  spec.add_dependency "kramdown", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.3"

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -1,21 +1,13 @@
+require "seo/filters.rb"
+
 module Jekyll
   class SeoTag < Liquid::Tag
 
     attr_accessor :context
 
-    HTML_ESCAPE = {
-      "\u201c".freeze => '&ldquo;'.freeze,
-      "\u201d".freeze => '&rdquo;'.freeze
-    }
-    HTML_ESCAPE_REGEX = Regexp.union(HTML_ESCAPE.keys).freeze
-
     def render(context)
       @context = context
       output = Liquid::Template.parse(template_contents).render!(payload, info)
-
-      # Encode smart quotes. See https://github.com/benbalter/jekyll-seo-tag/pull/6
-      output.gsub!(HTML_ESCAPE_REGEX, HTML_ESCAPE)
-
       output
     end
 
@@ -31,7 +23,7 @@ module Jekyll
     def info
       {
         :registers => context.registers,
-        :filters   => [Jekyll::Filters]
+        :filters   => [Jekyll::Filters, Jekyll::Seo::Filters]
       }
     end
 

--- a/lib/seo/filters.rb
+++ b/lib/seo/filters.rb
@@ -1,0 +1,22 @@
+class Kramdown::Parser::SmartyPants < Kramdown::Parser::Kramdown
+  def initialize(source, options)
+    super
+    @block_parsers = []
+    @span_parsers =  [:smart_quotes, :html_entity, :typographic_syms, :escaped_chars]
+  end
+end
+
+module Jekyll
+  module Seo
+    module Filters
+      MARKDOWN_OPTIONS = {
+        :entity_output => :symbolic,
+        :input => :SmartyPants
+      }
+
+      def smartify(input)
+        Kramdown::Document.new(input, MARKDOWN_OPTIONS).to_html.chomp
+      end
+    end
+  end
+end

--- a/lib/template.html
+++ b/lib/template.html
@@ -20,10 +20,10 @@
 	{% endif %}
 {% endif %}
 {% if seo_title %}
-  {% assign seo_title = seo_title | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_title = seo_title | smartify %}
 {% endif %}
 {% if seo_page_title %}
-  {% assign seo_page_title = seo_page_title | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_page_title = seo_page_title | smartify %}
 {% endif %}
 
 {% if page.description %}
@@ -32,7 +32,7 @@
   {% assign seo_description = site.description %}
 {% endif %}
 {% if seo_description %}
-  {% assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once %}
+  {% assign seo_description = seo_description | smartify %}
 {% endif %}
 
 {% if seo_title %}
@@ -54,12 +54,12 @@
 {% endif %}
 
 {% if site.title %}
-  <meta property="og:site_name" content="{{ site.title }}" />
+  <meta property="og:site_name" content="{{ site.title | smartify }}" />
   <script type="application/ld+json">
     {
       "@context" : "http://schema.org",
       "@type" : "WebSite",
-      "name" : {{ site.title | jsonify }},
+      "name" : {{ site.title | smartify | jsonify }},
       "url" : {{ seo_url | jsonify }}
     }
   </script>
@@ -72,19 +72,19 @@
 {% if page.date %}
   <meta property="og:type" content="article" />
   {% if page.next.url %}
-    <link rel="next" href="{{ page.next.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.next.title | escape }}" />
+    <link rel="next" href="{{ page.next.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.next.title | smartify }}" />
   {% endif %}
   {% if page.previous.url %}
-    <link rel="prev" href="{{ page.previous.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.previous.title | escape }}" />
+    <link rel="prev" href="{{ page.previous.url | prepend: seo_url | replace:'/index.html','/' }}" title="{{ page.previous.title | smartify }}" />
   {% endif %}
   <script type="application/ld+json">
     {
       "@context": "http://schema.org",
       "@type": "NewsArticle",
-      "headline": {{ page.title | jsonify }},
+      "headline": {{ seo_page_title | jsonify }},
       "image": {{ page.image | jsonify }},
       "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
-      "description": {{ page.description | jsonify }}
+      "description": {{ seo_description | jsonify }}
     }
   </script>
 {% endif %}


### PR DESCRIPTION
**kramdown** Is already required by both Jekyll 2 and 3, so this is not introducing a new dependency.

This creates a stripped down Kramdown Parser that is only concerned with quotes and typographic characters. Since it is natively encoding the smart quotes for us, there is no need for the `HTML_ESCAPE_REGEX` anymore.

The `smartify` filter is only available within our template, it is not available to regular Jekyll layouts.

Fixes #17