### PR TITLE
Minify template just once

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -13,9 +13,6 @@ module Jekyll
       @context = context
       output = Liquid::Template.parse(template_contents).render!(payload, info)
 
-      # Minify
-      output.gsub!(/[\s]{2,}/, "\n")
-
       # Encode smart quotes. See https://github.com/benbalter/jekyll-seo-tag/pull/6
       output.gsub!(HTML_ESCAPE_REGEX, HTML_ESCAPE)
 
@@ -39,7 +36,7 @@ module Jekyll
     end
 
     def template_contents
-      @template_contents ||= File.read(template_path)
+      @template_contents ||= File.read(template_path).gsub(/(>\n|[%}]})\s+(<|{[{%])/,'\1\2').chomp
     end
 
     def template_path


### PR DESCRIPTION
Instead of minifying the results each time the tag is rendered, minify the template when it is read from the file and never again.