### PR TITLE
Do not escape smart quotes

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -3,18 +3,9 @@ module Jekyll
 
     attr_accessor :context
 
-    HTML_ESCAPE = {
-      "\u201c".freeze => '&ldquo;'.freeze,
-      "\u201d".freeze => '&rdquo;'.freeze
-    }
-    HTML_ESCAPE_REGEX = Regexp.union(HTML_ESCAPE.keys).freeze
-
     def render(context)
       @context = context
       output = Liquid::Template.parse(template_contents).render!(payload, info)
-
-      # Encode smart quotes. See https://github.com/benbalter/jekyll-seo-tag/pull/6
-      output.gsub!(HTML_ESCAPE_REGEX, HTML_ESCAPE)
 
       output
     end

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -32,19 +32,6 @@ describe Jekyll::SeoTag do
     expect(subject.render(context)).to match(/<title>foo<\/title>/)
   end
 
-  it "escapes titles" do
-    site = site({"title" => 'Jekyll & "Hyde"'})
-    context = context({ :site => site })
-    expect(subject.render(context)).to match(/<title>Jekyll &amp; &ldquo;Hyde&rdquo;<\/title>/)
-  end
-
-  it "escapes descriptions" do
-    site = site({"description" => 'Jekyll & "Hyde"'})
-    context = context({ :site => site })
-    expected = /<meta name="description" content="Jekyll &amp; &ldquo;Hyde&rdquo;" \/>/
-    expect(subject.render(context)).to match(expected)
-  end
-
   it "uses the page description" do
     page = page({"description" => "foo"})
     context = context({ :page => page })


### PR DESCRIPTION
We should not be escaping special characters here. If the user has configured their Markdown processor to output Unicode characters, we should respect that. If a user wants to output special characters encoded as HTML entities, chances are they want that consistently across the site, not just in the `seo` tag.

I could add some tests to check if the output contains the special characters if so configured, if that would be useful.