### PR TITLE
Make <title> optional

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -3,6 +3,13 @@ module Jekyll
 
     attr_accessor :context
 
+    def initialize(_, markup, _)
+      super
+      @options = {
+        "title" => !(markup =~ /title\s*:\s*false/i)
+      }
+    end
+
     def render(context)
       @context = context
       output = template.render!(payload, info)
@@ -15,7 +22,8 @@ module Jekyll
     def payload
       {
         "page" => context.registers[:page],
-        "site" => context.registers[:site].site_payload["site"]
+        "site" => context.registers[:site].site_payload["site"],
+        "seo" => @options
       }
     end
 

--- a/lib/template.html
+++ b/lib/template.html
@@ -44,7 +44,7 @@
   {% assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
-{% if seo_title %}
+{% if seo_title and seo.title %}
   <title>{{ seo_title }}</title>
 {% endif %}
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -166,6 +166,14 @@ describe Jekyll::SeoTag do
     expect(subject.render(context)).to match(expected)
   end
 
+  it "does not output a <title> tag if title:false" do
+    site = site({"name" => "Site Name", "title" => "Site Title" })
+    context = context({ :site => site })
+    output = Liquid::Template.parse("{% seo title:false %}").render!(context, {})
+    expected = %r!<title>!
+    expect(output).not_to match(expected)
+  end
+
   it "outputs valid HTML" do
     site.process
     options = {


### PR DESCRIPTION
I am *very* picky about my `<title>` tags.

This PR provides a way to disable the plugin from outputting the `<title>` tag so that I can continue to use my own.

```html
{% seo title:false %}
```

By putting the option inside the tag, we avoid :christmas_tree:

Does this seem reasonable?