### PR TITLE
Lookup author in site.data.authors

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -36,11 +36,36 @@
 {% endif %}
 
 {% if page.author %}
-  {% assign seo_author_name = page.author.name | default: page.author %}
-  {% assign seo_author_twitter = page.author.twitter | default: page.author %}
+  {% if site.data.authors[page.author] %}
+    {% assign seo_author_name = site.data.authors[page.author].name %}
+    {% assign seo_author_twitter = site.data.authors[page.author].twitter | default: seo_author_name %}
+  {% elsif page.author.name %}
+    {% assign seo_author_name = page.author.name %}
+    {% assign seo_author_twitter = page.author.twitter | default: seo_author_name %}
+  {% elsif page.author.twitter %}
+    {% assign seo_author_twitter = page.author.twitter %}
+    {% assign seo_author_twitter = page.author.twitter %}
+  {% else %}
+    {% assign seo_author_name = page.author %}
+    {% assign seo_author_twitter = page.author %}
+  {% endif %}
+{% elsif site.author %}
+  {% if site.data.authors[site.author] %}
+    {% assign seo_author_name = site.data.authors[site.author].name %}
+    {% assign seo_author_twitter = site.data.authors[site.author].twitter | default: seo_author_name %}
+  {% elsif site.author.name %}
+    {% assign seo_author_name = site.author.name %}
+    {% assign seo_author_twitter = site.author.twitter | default: seo_author_name %}
+  {% else %}
+    {% assign seo_author_name = site.author %}
+    {% assign seo_author_twitter = site.author %}
+  {% endif %}
+{% endif %}
+{% if seo_author_name %}
+  {% assign seo_author_name = seo_author_name | strip_html | escape_once %}
 {% endif %}
 {% if seo_author_twitter %}
-  {% assign seo_author_twitter = seo_author_twitter | replace:"@","" | prepend:"@" %}
+  {% assign seo_author_twitter = seo_author_twitter | replace:"@","" | prepend:"@" | strip_html | escape_once %}
 {% endif %}
 
 {% if seo_title %}


### PR DESCRIPTION
Where will the plugin try to find a post author's Twitter username?

1. `site.data.authors[post.author].twitter`
2. `site.data.authors[post.author].name`
3. `post.author.twitter`
3. `post.author.name`
3. `post.author`
1. `site.data.authors[site.author].twitter`
2. `site.data.authors[site.author].name`
3. `site.author.twitter`
3. `site.author.name`
3. `site.author`

*Ugh.* I don't even begin to know how to document this. It is too bad that there isn't just one standard convention for all of this.

#31