### PR TITLE
Fix HTML5 validation error

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -77,7 +77,7 @@
 {% endif %}
 
 {% if seo_url %}
-  <link rel="canonical" href="{{ page.url | prepend: seo_url | replace:'/index.html','/' }}" itemprop="url" />
+  <link rel="canonical" href="{{ page.url | prepend: seo_url | replace:'/index.html','/' }}" />
   <meta property='og:url' content='{{ page.url | prepend: seo_url | replace:'/index.html','/' }}' />
 {% endif %}
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -56,7 +56,7 @@ describe Jekyll::SeoTag do
   it "uses the site url to build the seo url" do
     site = site({"url" => "http://example.invalid"})
     context = context({ :site => site })
-    expected = /<link rel="canonical" href="http:\/\/example.invalid\/page.html" itemprop="url" \/>/
+    expected = /<link rel="canonical" href="http:\/\/example.invalid\/page.html" \/>/
     expect(subject.render(context)).to match(expected)
     expected = /<meta property='og:url' content='http:\/\/example.invalid\/page.html' \/>/
     expect(subject.render(context)).to match(expected)
@@ -65,7 +65,7 @@ describe Jekyll::SeoTag do
   it "uses site.github.url to build the seo url" do
     site = site({"github" => { "url" => "http://example.invalid" }} )
     context = context({ :site => site })
-    expected = /<link rel="canonical" href="http:\/\/example.invalid\/page.html" itemprop="url" \/>/
+    expected = /<link rel="canonical" href="http:\/\/example.invalid\/page.html" \/>/
     expect(subject.render(context)).to match(expected)
     expected = /<meta property='og:url' content='http:\/\/example.invalid\/page.html' \/>/
     expect(subject.render(context)).to match(expected)
@@ -75,7 +75,7 @@ describe Jekyll::SeoTag do
     page = page({ "permalink" => "/page/index.html" })
     site = site({ "url" => "http://example.invalid" })
     context = context({ :page => page, :site => site })
-    expected = %r!<link rel="canonical" href="http://example.invalid/page/" itemprop="url" />!
+    expected = %r!<link rel="canonical" href="http://example.invalid/page/" />!
     expected = %r!<meta property='og:url' content='http://example.invalid/page/' />!
     expect(subject.render(context)).to match(expected)
   end
@@ -83,7 +83,7 @@ describe Jekyll::SeoTag do
   it "uses baseurl to build the seo url" do
     site = site({ "url" => "http://example.invalid", "baseurl" => "/foo" })
     context = context({ :site => site })
-    expected = %r!<link rel="canonical" href="http://example.invalid/foo/page.html" itemprop="url" />!
+    expected = %r!<link rel="canonical" href="http://example.invalid/foo/page.html" />!
     expect(subject.render(context)).to match(expected)
     expected = %r!<meta property='og:url' content='http://example.invalid/foo/page.html' />!
     expect(subject.render(context)).to match(expected)


### PR DESCRIPTION
Removed `itemprop` from canonical url due html validation error

See it in [this sample page] (http://cgarces.github.io/jekyll-seo-tag-test/jekyll/update/2016/01/29/welcome-to-jekyll.html) and  [the validation](https://validator.w3.org/nu/?doc=http%3A%2F%2Fcgarces.github.io%2Fjekyll-seo-tag-test%2Fjekyll%2Fupdate%2F2016%2F01%2F29%2Fwelcome-to-jekyll.html)

The url is already send in the ld+json data when `seo_site_title` is not null. Usually `seo_site_title` always will have a value assigned, 