### PR TITLE
Use seo_description instead of page.description

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -112,7 +112,7 @@
       "headline": {{ page.title | jsonify }},
       "image": {{ page.image | jsonify }},
       "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
-      "description": {{ page.description | jsonify }}
+      "description": {{ seo_description | jsonify }}
     }
   </script>
 {% endif %}


### PR DESCRIPTION
seo_description is used in  the meta tags but not in the ld+json
If page.description is not set, the the description at ld+json will be null.