### PR TITLE
Use seo_description instead of page.description

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -127,8 +127,8 @@
     "datePublished": {{ page.date | date_to_xmlschema | jsonify }},
 {% endif %}
 
-{% if page.description %}
-    "description": {{ page.description | jsonify }},
+{% if seo_description %}
+    "description": {{ seo_description | jsonify }},
 {% endif %}
 
 {% if site.logo %}


### PR DESCRIPTION
seo_description is used in the meta tags but not in the ld+json
If page.description is not set, the the description at ld+json will be null.

Meta tags and ld+json should use the same logic.
Same PR (#40) was send to main branch.