### PR TITLE
Make page.image url relative to site rather than absolute

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 
 * `title` - The title of the post, page, or document
 * `description` - A short description of the page's content
-* `image` - The absolute URL to an image that should be associated with the post, page, or document
+* `image` - Relative URL to an image associated with the post, page, or document (e.g., `assets/page-pic.jpg`)
 * `author` - The username of the post, page, or document author

--- a/lib/template.html
+++ b/lib/template.html
@@ -94,7 +94,7 @@
 {% endif %}
 
 {% if page.image %}
-  <meta property="og:image" content="{{ page.image }}" />
+  <meta property="og:image" content="{{ page.image | prepend: "/" | prepend: seo_url | escape }}" />
 {% endif %}
 
 {% if page.date %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -153,9 +153,10 @@ describe Jekyll::SeoTag do
   end
 
   it "outputs the image" do
-    page = page({"image" => "http://foo.invalid/foo.png"})
-    context = context({ :page => page })
-    expected = /<meta property="og:image" content="http:\/\/foo.invalid\/foo.png" \/>/
+    page = page({ "image" => "foo.png" })
+    site = site({ "url" => "http://example.invalid" })
+    context = context({ :page => page, :site => site })
+    expected = %r!<meta property="og:image" content="http://example.invalid/foo.png" />!
     expect(subject.render(context)).to match(expected)
   end
 


### PR DESCRIPTION
Fixes #24 

Tests pass when https://github.com/benbalter/jekyll-seo-tag/pull/43 is merged,