### PR TITLE
Expose version in HTML comment

### DIFF
--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -18,8 +18,8 @@ module Jekyll
     def payload
       {
         'seo_tag' => { 'version' => VERSION },
-        'page' => context.registers[:page],
-        'site' => context.registers[:site].site_payload['site']
+        'page'    => context.registers[:page],
+        'site'    => context.registers[:site].site_payload['site']
       }
     end
 

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -17,6 +17,7 @@ module Jekyll
 
     def payload
       {
+        'seo_tag' => { 'version' => VERSION },
         'page' => context.registers[:page],
         'site' => context.registers[:site].site_payload['site']
       }

--- a/lib/template.html
+++ b/lib/template.html
@@ -1,4 +1,4 @@
-<!-- Begin Jekyll SEO tag -->
+<!-- Begin Jekyll SEO tag v{{ seo_tag.version }} -->
 
 {% if site.url %}
   {% assign seo_url = site.url | append: site.baseurl %}

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -193,4 +193,9 @@ describe Jekyll::SeoTag do
     status = HTML::Proofer.new(dest_dir, options).run
     expect(status).to eql(true)
   end
+
+  it 'outputs the plugin version' do
+    version = Jekyll::SeoTag::VERSION
+    expect(subject.render(context)).to match(/Jekyll SEO tag v#{version}/i)
+  end
 end


### PR DESCRIPTION
This changes the HTML comment from `<!-- Begin Jekyll SEO tag -->` to `<!-- Begin Jekyll SEO tag v1.1.0 -->` for easier debugging