### PR TITLE
Make <title> Optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,14 @@ The SEO tag will respect the following YAML front matter if included in a post, 
 * `image` - Relative URL to an image associated with the post, page, or document (e.g., `assets/page-pic.jpg`)
 * `author` - Page-, post-, or document-specific author information (see below)
 
+### Disabling `<title>` output
+
+Jekyll SEO Tag is designed to implement SEO best practices by default. If for some reason, you don't want the plugin to output `<title>` tags on each page, simply invoke the plugin within your template like so:
+
+```
+{% seo title=false %}
+```
+
 ### Author information
 
 Author information is used to propagate the `creator` field of Twitter summary cards. This is should be an author-specific, not site-wide Twitter handle (the site-wide username be stored as `site.twitter.username`).

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -3,6 +3,13 @@ module Jekyll
 
     attr_accessor :context
 
+    def initialize(_, markup, _)
+      super
+      @options = {
+        "title" => !(markup =~ /title\s*:\s*false/i)
+      }
+    end
+
     def render(context)
       @context = context
       output = template.render!(payload, info)
@@ -15,7 +22,8 @@ module Jekyll
     def payload
       {
         "page" => context.registers[:page],
-        "site" => context.registers[:site].site_payload["site"]
+        "site" => context.registers[:site].site_payload["site"],
+        "seo" => @options
       }
     end
 

--- a/lib/jekyll-seo-tag.rb
+++ b/lib/jekyll-seo-tag.rb
@@ -21,7 +21,7 @@ module Jekyll
     def options
       {
         'version' => VERSION,
-        "title" => !(@text =~ /title\s*:\s*false/i)
+        'title'   => title?
       }
     end
 
@@ -31,6 +31,10 @@ module Jekyll
         'site'    => context.registers[:site].site_payload['site'],
         'seo_tag' => options
       }
+    end
+
+    def title?
+      !(@text =~ /title=false/i)
     end
 
     def info

--- a/lib/template.html
+++ b/lib/template.html
@@ -44,7 +44,7 @@
   {% assign seo_description = seo_description | markdownify | strip_html | strip_newlines | escape_once %}
 {% endif %}
 
-{% if seo_title %}
+{% if seo_title and seo.title %}
   <title>{{ seo_title }}</title>
 {% endif %}
 

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -166,6 +166,14 @@ describe Jekyll::SeoTag do
     expect(subject.render(context)).to match(expected)
   end
 
+  it "does not output a <title> tag if title:false" do
+    site = site({"name" => "Site Name", "title" => "Site Title" })
+    context = context({ :site => site })
+    output = Liquid::Template.parse("{% seo title:false %}").render!(context, {})
+    expected = %r!<title>!
+    expect(output).not_to match(expected)
+  end
+
   it "outputs valid HTML" do
     site.process
     options = {

--- a/spec/jekyll_seo_tag_spec.rb
+++ b/spec/jekyll_seo_tag_spec.rb
@@ -1,15 +1,14 @@
 require 'spec_helper'
 
 describe Jekyll::SeoTag do
-#  subject { Jekyll::SeoTag.parse('seo', nil, nil, nil) }
-  let(:page) { make_page }
-  let(:site) { make_site }
-  let(:post) { make_post }
-  let(:context) { make_context(page: page, site: site) }
-  let(:tag) { 'seo' }
-  let(:text) { '' }
-  let(:output) { Liquid::Template.parse("{% #{tag} #{text} %}").render!(context, {}) }
-  let(:json) { output.match(%r{<script type=\"application/ld\+json\">(.*)</script>}m)[1] }
+  let(:page)      { make_page }
+  let(:site)      { make_site }
+  let(:post)      { make_post }
+  let(:context)   { make_context(page: page, site: site) }
+  let(:tag)       { 'seo' }
+  let(:text)      { '' }
+  let(:output)    { Liquid::Template.parse("{% #{tag} #{text} %}").render!(context, {}) }
+  let(:json)      { output.match(%r{<script type=\"application/ld\+json\">(.*)</script>}m)[1] }
   let(:json_data) { JSON.parse(json) }
 
   before do
@@ -102,6 +101,7 @@ describe Jekyll::SeoTag do
 
     context 'with site.baseurl' do
       let(:site) { make_site('url' => 'http://example.invalid', 'baseurl' => '/foo') }
+
       it 'uses baseurl to build the seo url' do
         expected = %r{<link rel="canonical" href="http://example.invalid/foo/page.html" />}
         expect(output).to match(expected)
@@ -281,14 +281,12 @@ describe Jekyll::SeoTag do
   end
 
   context 'with title=false' do
-    it "does not output a <title> tag if title:false" do
-      site = site({"name" => "Site Name", "title" => "Site Title" })
-      context = context({ :site => site })
-      expected = %r!<title>!
-      expect(output).not_to match(expected)
+    let(:text) { 'title=false' }
+
+    it 'does not output a <title> tag' do
+      expect(output).not_to match(/<title>/)
     end
   end
-
 
   it 'outputs valid HTML' do
     site.process


### PR DESCRIPTION
Based on @pathawks's https://github.com/benbalter/jekyll-seo-tag/pull/29. With the following additions:

* Merged in `master`, which changed the way tests are implemented
* Use the documented `initialize` argument names for consistency
* Move `options` and `title?` to their own methods for simplicity
* Use the (now) existing `seo_tag`, rather than the `seo` context namespace
* Use `title=false` rather than `title: false` to retain consistency with things like the include tag, which uses the `key=value` format for passing argument to tags.
* Add documentation